### PR TITLE
Load SQL-Luas only if convar is set.

### DIFF
--- a/betting/lua/autorun/server/sv_karma_betting_mysql.lua
+++ b/betting/lua/autorun/server/sv_karma_betting_mysql.lua
@@ -1,7 +1,7 @@
 -- Made by Luk
 -- http://steamcommunity.com/id/doctorluk/
 
-if SERVER then
+if SERVER and GetConVar( "karmabet_savemode" ):GetString() == "mysql" then
 
 	require( "mysqloo" )
 	local db


### PR DESCRIPTION
Getting convar and only load mysql or sqlite if module is there, so that you don't get a LUA Error if not configured.